### PR TITLE
Update to new lifecycle hook, `package` to remove deprecation warning

### DIFF
--- a/add-log-retention.js
+++ b/add-log-retention.js
@@ -16,7 +16,7 @@ class AwsAddLogRetention {
     this.options = options;
     this.provider = this.serverless.getProvider('aws');
     this.hooks = {
-      'before:deploy:createDeploymentArtifacts': this.beforeDeploy.bind(this),
+      'package:createDeploymentArtifacts': this.beforeDeploy.bind(this),
     };
   }
 

--- a/test/add-log-retention.js
+++ b/test/add-log-retention.js
@@ -37,10 +37,10 @@ describe('serverless-plugin-log-retention', function() {
       const instance = createTestInstance();
       expect(instance)
         .to.have.property('hooks')
-        .that.has.all.keys('before:deploy:createDeploymentArtifacts');
+        .that.has.all.keys('package:createDeploymentArtifacts');
 
       const stub = sinon.stub(instance, 'addLogRetentionForFunctions');
-      instance.hooks['before:deploy:createDeploymentArtifacts']();
+      instance.hooks['package:createDeploymentArtifacts']();
 
       sinon.assert.calledOnce(stub);
     });


### PR DESCRIPTION
Usage invokes the following warning from SLS:
`Serverless: WARNING: Plugin AwsAddLogRetention uses deprecated hook before:deploy:createDeploymentArtifacts,
                     use package:createDeploymentArtifacts hook instead`

1) Update to new life cycle method `package`
2) Update Tests

Making this change removes the deprecation warning when deploying.