### PR TITLE
add resources reference if missing

### DIFF
--- a/add-log-retention.js
+++ b/add-log-retention.js
@@ -35,7 +35,12 @@ class AwsAddLogRetention {
       return;
     }
 
-    const resources = nco(service.resources, {});
+
+    if(typeof service.resources !== 'object') {
+      service.resources = {};
+    }
+
+    const resources = service.resources;
     resources.Resources = nco(resources.Resources, {});
 
     Object.keys(service.functions).forEach(functionName => {

--- a/test/add-log-retention.js
+++ b/test/add-log-retention.js
@@ -44,6 +44,52 @@ describe('serverless-plugin-log-retention', function() {
 
       sinon.assert.calledOnce(stub);
     });
+
+    it('should create missing resources block', function() {
+      const instance = createTestInstance({
+        resources: undefined,
+        functions: {TestFunc: {logRetentionInDays: 30}}
+      });
+
+      expect(instance.serverless.service.resources)
+        .not.to.be.a('object');
+
+      instance.hooks['package:createDeploymentArtifacts']();
+
+      expect(instance.serverless.service.resources)
+        .to.have.property('Resources')
+        .that.have.property('TestFuncLogGroup')
+          .that.deep.equal({
+            Type: 'AWS::Logs::LogGroup',
+            Properties: {
+              RetentionInDays: 30
+            }
+          });
+    });
+
+    it('should update existing resources block', function() {
+      const instance = createTestInstance({
+        resources: {SampleRes: {}},
+        functions: {TestFunc: {logRetentionInDays: 30}}
+      });
+
+      expect(instance.serverless.service.resources)
+        .to.be.a('object')
+        .that.have.property('Resources')
+          .that.have.property('SampleRes');
+
+      instance.hooks['package:createDeploymentArtifacts']();
+
+      expect(instance.serverless.service.resources)
+        .to.have.property('Resources')
+        .that.have.property('TestFuncLogGroup')
+        .that.deep.equal({
+          Type: 'AWS::Logs::LogGroup',
+          Properties: {
+            RetentionInDays: 30
+          }
+        });
+    });
   })
 
 });


### PR DESCRIPTION
This PR fixes following problem:

Log group retention remains **Never** as CFN is not aware of `AWS::Logs::LogGroup` resource, if `serverless.yml` file does not have `resources` defined. 

As a workaround `serverless.yml` must have empty block, which is not very convenient to have:

```yaml
resources: {}
```