### PR TITLE
Log retention is not set when threre no aws resources in project

### DIFF
--- a/add-log-retention.js
+++ b/add-log-retention.js
@@ -35,7 +35,9 @@ class AwsAddLogRetention {
       return;
     }
 
-    const resources = nco(service.resources, {});
+    service.resources = nco(service.resources, {});
+
+    const resources = service.resources;
     resources.Resources = nco(resources.Resources, {});
 
     Object.keys(service.functions).forEach(functionName => {


### PR DESCRIPTION
If the project contains none aws resources, the log retention is not set, this happens due to a bug in the implementation logic.